### PR TITLE
Use default Ubuntu repository for llvm packages

### DIFF
--- a/full/Dockerfile
+++ b/full/Dockerfile
@@ -10,10 +10,7 @@ LABEL dazzle/test=tests/lang-c.yaml
 USER root
 # Dazzle does not rebuild a layer until one of its lines are changed. Increase this counter to rebuild this layer.
 ENV TRIGGER_REBUILD=3
-RUN curl -o /var/lib/apt/dazzle-marks/llvm.gpg -fsSL https://apt.llvm.org/llvm-snapshot.gpg.key \
-    && apt-key add /var/lib/apt/dazzle-marks/llvm.gpg \
-    && echo "deb https://apt.llvm.org/focal/ llvm-toolchain-focal main" >> /etc/apt/sources.list.d/llvm.list \
-    && install-packages \
+RUN install-packages \
         clang \
         clangd \
         clang-format \

--- a/full/Dockerfile.arm64
+++ b/full/Dockerfile.arm64
@@ -10,10 +10,7 @@ LABEL dazzle/test=tests/lang-c.yaml
 USER root
 # Dazzle does not rebuild a layer until one of its lines are changed. Increase this counter to rebuild this layer.
 ENV TRIGGER_REBUILD=3
-RUN curl -o /var/lib/apt/dazzle-marks/llvm.gpg -fsSL https://apt.llvm.org/llvm-snapshot.gpg.key \
-    && apt-key add /var/lib/apt/dazzle-marks/llvm.gpg \
-    && echo "deb https://apt.llvm.org/focal/ llvm-toolchain-focal main" >> /etc/apt/sources.list.d/llvm.list \
-    && install-packages \
+RUN install-packages \
         clang \
         clangd \
         clang-format \


### PR DESCRIPTION
Repository https://apt.llvm.org doesn't provide ARM64 packages.
But required packages were found in the default repository for Ubuntu. 